### PR TITLE
Add support for arbitrary git repositories

### DIFF
--- a/examples/giternity.toml
+++ b/examples/giternity.toml
@@ -31,3 +31,19 @@ repositories = [
     "sunsistemo",
     "TeMPOraL/nyan-mode",
 ]
+
+# Include arbitrary repositories with this pattern (1 [[repos]] block
+# each):
+#
+#    [[repos]]
+#    name = "repo-name"
+#    owner = "owner"
+#    description = "description"
+#    homepage = "https://example.local"
+#    clone_url = "https://git.example.local/owner/repo-name.git"
+[[repos]]
+name = "linux"
+owner = "torvalds"
+description = "Linux Kernel"
+homepage = "https://kernel.org"
+clone_url = "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"

--- a/giternity.py
+++ b/giternity.py
@@ -254,6 +254,19 @@ def main():
                     url = repo["clone_url"]
                     metadata = gh_api.repo_to_cgitrc(repo)
                     archive_plan.append((repo, metadata, url, path))
+    else:
+        gh_api = GitHub(cgit_url=cgit_url, token='')
+    
+    # Arbitrary git repositories
+    arbitrary_repos = config.get("repos")
+    if arbitrary_repos:
+        for repo in arbitrary_repos:
+            repo['full_name'] = '{}/{}'.format(repo['owner'], repo['name'])
+            log.debug("Configuring repo %s", repo['full_name'])
+            path = "{}{}{}".format(git_data_path, repo['full_name'], checkout_suffix)
+            url = repo["clone_url"]
+            metadata = gh_api.repo_to_cgitrc(repo)
+            archive_plan.append((repo, metadata, url, path))
 
     if args.dry_run:
         for repo, metadata, url, path in archive_plan:


### PR DESCRIPTION
This patch adds support for arbitrary repositories hosted with sites
other than GitHub. Each must be defined in its own `[[repos]]` block in
the configuration TOML file.

ref: https://github.com/rahiel/giternity/issues/2